### PR TITLE
Replace vnc implementation with vnc-rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,8 @@ jobs:
         run: |
           cargo deb
           # Fix the tilde-name that happens on alpha builds
-          mv target/debian/scrying_*_amd64.deb \
-            target/debian/scrying_${{ needs.create_new_release.outputs.version_num }}_amd64.deb
+          #mv target/debian/scrying_*_amd64.deb \
+          #  target/debian/scrying_${{ needs.create_new_release.outputs.version_num }}_amd64.deb
 
       - name: Zip binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1358,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1725,7 @@ dependencies = [
  "tokio",
  "url",
  "vnc",
+ "vnc-rs",
 ]
 
 [[package]]
@@ -1770,6 +1800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2015,10 +2054,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
+ "bytes",
  "libc",
+ "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -2051,6 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log 0.4.17",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2203,6 +2247,19 @@ dependencies = [
  "byteorder 0.5.3",
  "flate2 0.2.20",
  "log 0.3.9",
+]
+
+[[package]]
+name = "vnc-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa575d4f8c5cb9073acd2ffb5dacf9e22f6abd5426065a6cf46cf80ee200b1c1"
+dependencies = [
+ "anyhow",
+ "flate2 1.0.24",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 name = "scrying"
 version = "0.9.0"
 dependencies = [
+ "anyhow",
  "askama",
  "chromiumoxide",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [features]
 
 [dependencies]
+anyhow = "1"
 askama = "0.11"
 clap = { version = "3", features = ["cargo", "derive"] }
 color-eyre = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ simplelog = "0.12"
 socks = "0.3"
 url = "2.1.1"
 vnc = "0.4"
+vnc-rs = { version = "0.3", package = "vnc-rs" }
 
 [dependencies.chromiumoxide]
 version = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,9 +313,8 @@ async fn vnc_worker(
                 let opts_clone = opts.clone();
                 let tx = thread_status_tx.clone();
                 let report_tx_clone = report_tx.clone();
-                let handle = tokio::task::spawn(async move {
+                let handle = tokio::task::spawn({
                     vnc2::capture(&target, &opts_clone, tx, &report_tx_clone)
-                        .await
                 });
 
                 workers.push(handle);

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -25,7 +25,8 @@ use askama::Template;
 use color_eyre::Result;
 use std::fs;
 use std::path::Path;
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
+use tokio::sync::mpsc;
 
 #[allow(unused)]
 use log::{debug, error, info, trace, warn};
@@ -74,8 +75,8 @@ pub enum FileError {
     Error(String),
 }
 
-pub fn reporting_thread(
-    rx: mpsc::Receiver<ReportMessage>,
+pub async fn reporting_thread(
+    mut rx: mpsc::Receiver<ReportMessage>,
     opts: Arc<Opts>,
     targets: Arc<InputLists>,
 ) -> Result<()> {
@@ -90,7 +91,7 @@ pub fn reporting_thread(
     let mut vnc_errors: Vec<ReportError> = Vec::new();
 
     // Main loop listening on the channel
-    while let Ok(msg) = rx.recv() {
+    while let Some(msg) = rx.recv().await {
         use ReportMessage::*;
         debug!("Received message: {:?}", msg);
         match msg {

--- a/src/web/chrome.rs
+++ b/src/web/chrome.rs
@@ -10,8 +10,9 @@ use color_eyre::{eyre::eyre, Result};
 use futures::StreamExt;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    mpsc, Arc,
+    Arc,
 };
+use tokio::sync::mpsc;
 
 pub async fn chrome_worker(
     targets: Arc<InputLists>,


### PR DESCRIPTION
vnc-rs is fully async and generic over `AsyncRead + AsyncWrite` so it will be usable over a socks proxy and makes it slightly easier to implement timeouts. Drawbacks are that it exposes `anyhow::Error` in its public API and it's not possible to initiate a connection from a tokio task because `VncConnector` is `!Send`.